### PR TITLE
C30V Diagram

### DIFF
--- a/include/Diagram.h
+++ b/include/Diagram.h
@@ -267,10 +267,7 @@ class C30 : public DiagramNumeric<cmplx> {
 
 class C30V : public DiagramNumeric<compcomp_t> {
  public:
-  C30V(std::vector<CorrInfo> const &corr_lookup,
-       std::string const &output_path,
-       std::string const &output_filename,
-       int const Lt);
+  using DiagramNumeric<compcomp_t>::DiagramNumeric;
 
   char const *name() const override { return "C30V"; }
 

--- a/include/Diagram.h
+++ b/include/Diagram.h
@@ -274,6 +274,21 @@ class C30 : public DiagramNumeric<cmplx> {
   std::vector<std::tuple<std::array<size_t, 2>, std::array<size_t, 1>>> quantum_num_ids_;
 };
 
+class C30V : public DiagramNumeric<compcomp_t> {
+ public:
+  C30V(std::vector<CorrInfo> const &corr_lookup,
+       std::string const &output_path,
+       std::string const &output_filename,
+       int const Lt);
+
+  char const *name() const override { return "C30V"; }
+
+ private:
+  void contract_impl(std::vector<compcomp_t> &c,
+                     BlockIterator const &slice_pair,
+                     QuarkLineBlockCollection &q) override;
+};
+
 /*****************************************************************************/
 /*                                   C4                                     */
 /*****************************************************************************/

--- a/modules/Correlators.cpp
+++ b/modules/Correlators.cpp
@@ -128,6 +128,7 @@ void Correlators::contract(OperatorsForMesons const &meson_operator,
 
   diagrams.emplace_back(new C3c(corr_lookup.C3c, output_path, output_filename, Lt));
   diagrams.emplace_back(new C30(corr_lookup.C30, output_path, output_filename, Lt));
+  diagrams.emplace_back(new C30V(corr_lookup.C30V, output_path, output_filename, Lt));
 
   diagrams.emplace_back(new C4cB(corr_lookup.C4cB, output_path, output_filename, Lt));
   diagrams.emplace_back(new C40B(corr_lookup.C40B, output_path, output_filename, Lt));

--- a/modules/Diagram.cpp
+++ b/modules/Diagram.cpp
@@ -126,12 +126,6 @@ void C30::contract_impl(std::vector<cmplx> &c,
 /*                                   C30V                                    */
 /*****************************************************************************/
 
-C30V::C30V(std::vector<CorrInfo> const &corr_lookup,
-           std::string const &output_path,
-           std::string const &output_filename,
-           int const Lt)
-    : DiagramNumeric<compcomp_t>(corr_lookup, output_path, output_filename, Lt) {}
-
 void C30V::contract_impl(std::vector<compcomp_t> &c,
                          BlockIterator const &slice_pair,
                          QuarkLineBlockCollection &q) {

--- a/modules/Diagram.cpp
+++ b/modules/Diagram.cpp
@@ -141,6 +141,28 @@ void C30::contract_impl(std::vector<cmplx> &c,
 }
 
 /*****************************************************************************/
+/*                                   C30V                                    */
+/*****************************************************************************/
+
+C30V::C30V(std::vector<CorrInfo> const &corr_lookup,
+           std::string const &output_path,
+           std::string const &output_filename,
+           int const Lt)
+    : DiagramNumeric<compcomp_t>(corr_lookup, output_path, output_filename, Lt) {}
+
+void C30V::contract_impl(std::vector<compcomp_t> &c,
+                         BlockIterator const &slice_pair,
+                         QuarkLineBlockCollection &q) {
+  for (int i = 0; i != corr_lookup().size(); ++i) {
+    auto const &c_look = corr_lookup()[i];
+
+    c[i] +=
+        inner_product(q.corr_part_trQ1[c_look.lookup[0]][slice_pair.source()],
+                      q.corr0[c_look.lookup[1]][slice_pair.sink()][slice_pair.sink()]);
+  }
+}
+
+/*****************************************************************************/
 /*                                   C4cD                                    */
 /*****************************************************************************/
 

--- a/modules/Diagram.cpp
+++ b/modules/Diagram.cpp
@@ -157,8 +157,8 @@ void C30V::contract_impl(std::vector<compcomp_t> &c,
     auto const &c_look = corr_lookup()[i];
 
     c[i] +=
-        inner_product(q.corr_part_trQ1[c_look.lookup[0]][slice_pair.source()],
-                      q.corr0[c_look.lookup[1]][slice_pair.sink()][slice_pair.sink()]);
+        inner_product(q.corr_part_trQ1[c_look.lookup[1]][slice_pair.source()],
+                      q.corr0[c_look.lookup[0]][slice_pair.sink()][slice_pair.sink()]);
   }
 }
 

--- a/modules/Diagram.cpp
+++ b/modules/Diagram.cpp
@@ -133,8 +133,8 @@ void C30V::contract_impl(std::vector<compcomp_t> &c,
     auto const &c_look = corr_lookup()[i];
 
     c[i] +=
-        inner_product(q.corr_part_trQ1[c_look.lookup[1]][slice_pair.source()],
-                      q.corr0[c_look.lookup[0]][slice_pair.sink()][slice_pair.sink()]);
+        inner_product(q.corr0[c_look.lookup[0]][slice_pair.source()][slice_pair.source()],
+                      q.corr_part_trQ1[c_look.lookup[1]][slice_pair.sink()]);
   }
 }
 

--- a/modules/GlobalData/init_lookup_tables.cpp
+++ b/modules/GlobalData/init_lookup_tables.cpp
@@ -1002,14 +1002,14 @@ static void build_C30V_lookup(
     build_Quarkline_lookup_one_qn(
         2, quantum_numbers[d], vdv_indices[d], ric_ids, Q1_lookup, ql_ids);
 
-    auto const id1 = build_corr0_lookup({ql_ids[0], ql_ids[1]}, trQ1Q1_lookup);
-    auto const id2 = build_trQ1_lookup({ql_ids[2]}, trQ1_lookup);
+    auto const id0 = build_corr0_lookup({ql_ids[0], ql_ids[1]}, trQ1Q1_lookup);
+    auto const id1 = build_trQ1_lookup({ql_ids[2]}, trQ1_lookup);
 
     std::string const hdf5_dataset_name = build_hdf5_dataset_name(
         "C30V", start_config, path_output, overwrite, quark_types, quantum_numbers[d]);
 
     CorrInfo const candidate{
-        c_look.size(), hdf5_dataset_name, {id1, id2}, std::vector<int>{}};
+        c_look.size(), hdf5_dataset_name, {id0, id1}, std::vector<int>{}};
 
     /*! XXX Better with std::set */
     auto const it = std::find(c_look.begin(), c_look.end(), candidate);

--- a/modules/GlobalData/init_lookup_tables.cpp
+++ b/modules/GlobalData/init_lookup_tables.cpp
@@ -993,9 +993,11 @@ static void build_C30V_lookup(
     ric_ids = create_rnd_vec_id(quarks, quark_numbers[1], quark_numbers[0], false);
     build_Quarkline_lookup_one_qn(
         0, quantum_numbers[d], vdv_indices[d], ric_ids, Q1_lookup, ql_ids);
+
     ric_ids = create_rnd_vec_id(quarks, quark_numbers[0], quark_numbers[1], false);
     build_Quarkline_lookup_one_qn(
         1, quantum_numbers[d], vdv_indices[d], ric_ids, Q1_lookup, ql_ids);
+
     ric_ids = create_rnd_vec_id(quarks, quark_numbers[2], quark_numbers[2], true);
     build_Quarkline_lookup_one_qn(
         2, quantum_numbers[d], vdv_indices[d], ric_ids, Q1_lookup, ql_ids);

--- a/modules/GlobalData/init_lookup_tables.cpp
+++ b/modules/GlobalData/init_lookup_tables.cpp
@@ -1009,7 +1009,7 @@ static void build_C30V_lookup(
         "C30V", start_config, path_output, overwrite, quark_types, quantum_numbers[d]);
 
     CorrInfo const candidate{
-        c_look.size(), hdf5_dataset_name, {id1, id2}, std::vector<int>({})};
+        c_look.size(), hdf5_dataset_name, {id1, id2}, std::vector<int>{}};
 
     /*! XXX Better with std::set */
     auto const it = std::find(c_look.begin(), c_look.end(), candidate);

--- a/modules/GlobalData/init_lookup_tables.cpp
+++ b/modules/GlobalData/init_lookup_tables.cpp
@@ -985,8 +985,9 @@ static void build_C30V_lookup(
 
   // Build the correlator and dataset names for hdf5 output files
   std::vector<std::string> quark_types;
-  for (const auto &id : quark_numbers)
+  for (const auto &id : quark_numbers) {
     quark_types.emplace_back(quarks[id].type);
+  }
 
   for (size_t d = 0; d < quantum_numbers.size(); ++d) {
     ric_ids = create_rnd_vec_id(quarks, quark_numbers[1], quark_numbers[0], false);

--- a/modules/GlobalData/init_lookup_tables.cpp
+++ b/modules/GlobalData/init_lookup_tables.cpp
@@ -999,17 +999,17 @@ static void build_C30V_lookup(
     build_Quarkline_lookup_one_qn(
         2, quantum_numbers[d], vdv_indices[d], ric_ids, Q1_lookup, ql_ids);
 
-    auto id1 = build_corr0_lookup({ql_ids[0], ql_ids[1]}, trQ1Q1_lookup);
-    auto id2 = build_trQ1_lookup({ql_ids[2]}, trQ1_lookup);
+    auto const id1 = build_corr0_lookup({ql_ids[0], ql_ids[1]}, trQ1Q1_lookup);
+    auto const id2 = build_trQ1_lookup({ql_ids[2]}, trQ1_lookup);
 
-    std::string hdf5_dataset_name = build_hdf5_dataset_name(
+    std::string const hdf5_dataset_name = build_hdf5_dataset_name(
         "C30V", start_config, path_output, overwrite, quark_types, quantum_numbers[d]);
 
-    CorrInfo candidate{
+    CorrInfo const candidate{
         c_look.size(), hdf5_dataset_name, {id1, id2}, std::vector<int>({})};
 
     /*! XXX Better with std::set */
-    auto it = std::find(c_look.begin(), c_look.end(), candidate);
+    auto const it = std::find(c_look.begin(), c_look.end(), candidate);
 
     if (it == c_look.end()) {
       c_look.push_back(candidate);


### PR DESCRIPTION
I have attempted to add the C30V diagram. As you have said the IDs are switched, so that the `tr(Q1)` object is `id[1]` and the `corr0` object is `id[0]`.

Can we please check that this is correct? If so, I would use C20V and C30V in production.